### PR TITLE
Added inline containers

### DIFF
--- a/fab-dev/src/App.js
+++ b/fab-dev/src/App.js
@@ -21,7 +21,7 @@ class App extends Component {
             Learn React
           </a>
           <Container>
-            <Link 
+            <Link
             tooltip={"Ação 0"}
             icon="fas fa-plus" href="/baaah" styles={{backgroundColor: darkColors.purple, color: lightColors.cyan}}/>
             <Link
@@ -32,6 +32,16 @@ class App extends Component {
             // icon="fas fa-plus"
             rotate={true}
             >Bah!</Button>
+          </Container>
+          <Container styles={{ right: '20vw' }} inline>
+            <Link
+              tooltip={"Ação 0"}
+              icon="fas fa-plus"
+              href="/baaah"
+              styles={{backgroundColor: darkColors.purple, color: lightColors.cyan}}
+            />
+            <Link tooltip={"Ação 0"} icon="fas fa-plus" href="/baaah"/>
+            <Button tooltip={"Ação 0"} tooltip="Inline container" rotate>Bah!</Button>
           </Container>
         </header>
       </div>

--- a/lib/src/css/FAB.css
+++ b/lib/src/css/FAB.css
@@ -24,12 +24,12 @@
   margin: 20px auto 0;
   position: relative;
   -webkit-transition: transform .1s ease-out, height 100ms ease, opacity 100ms ease;
-          transition: transform .1s ease-out, height 100ms ease, opacity 100ms ease;  
+          transition: transform .1s ease-out, height 100ms ease, opacity 100ms ease;
   text-decoration: none;
 }
 
-.fab-item:active, 
-.fab-item:focus, 
+.fab-item:active,
+.fab-item:focus,
 .fab-item:hover {
   box-shadow: 0 10px 20px rgba(0,0,0,0.19), 0 6px 6px rgba(0,0,0,0.23);
   transition: box-shadow .2s ease;
@@ -46,7 +46,7 @@
   transform: translateY(50px);
 }
 
-.fab-container:hover 
+.fab-container:not(.fab-container-inline):hover
 .fab-item:not(:last-child) {
   height: 40px;
   opacity: 1;
@@ -56,11 +56,11 @@
   margin: 15px auto 0;
 }
 
-.fab-item:not(:last-child) i{
+.fab-container:not(.fab-container-inline) > .fab-item:not(:last-child) i{
   opacity: 0;
 }
 
-.fab-container:hover 
+.fab-container:hover
 .fab-item:not(:last-child) i {
   opacity: 1;
 }
@@ -119,9 +119,9 @@
   transition: opacity .1s step-end;
 }
 
-.fab-item.fab-rotate:active, 
-.fab-item.fab-rotate:focus, 
-.fab-item.fab-rotate:hover 
+.fab-item.fab-rotate:active,
+.fab-item.fab-rotate:focus,
+.fab-item.fab-rotate:hover
 {
   transform: rotate(45deg);
   box-shadow: 5px 5px 20px rgba(0,0,0,0.19), 3px 3px 6px rgba(0,0,0,0.23);
@@ -130,9 +130,19 @@
 }
 
 .fab-item.fab-rotate:nth-last-child(1)[tooltip]:hover:before,
-.fab-item.fab-rotate:nth-last-child(1)[tooltip]:hover:after 
+.fab-item.fab-rotate:nth-last-child(1)[tooltip]:hover:after
 {
   transform: rotate(-45deg);
   bottom: -60%;
   right: 60%;
+}
+
+.fab-container-inline > .fab-item:not(:last-child) {
+  height: 56px;
+  width: 58px;
+  opacity: 1;
+  -webkit-transform: none;
+  -ms-transform: none;
+  transform: none;
+  margin: 15px auto 0;
 }

--- a/lib/src/index.js
+++ b/lib/src/index.js
@@ -4,7 +4,7 @@ import {darkColors, lightColors} from './js/MaterialColors'
 
 const Container = props => {
     return (
-        <nav className={`fab-container ${props.className}`} style={props.styles}>
+        <nav className={`fab-container ${props.className} ${props.inline ? 'fab-container-inline' : ''}`} style={props.styles}>
             {props.children}
         </nav>
     )


### PR DESCRIPTION
It looks like this:
![image](https://user-images.githubusercontent.com/18128642/94967186-fb434600-04d4-11eb-80f0-178403c0f92e.png)

To create them just add the ``inline`` prop to the ``<Container/>`` tag, like this:
```jsx
<Container inline>
  <Link
    tooltip={"Ação 0"}
    icon="fas fa-plus"
    href="/baaah"
    styles={{backgroundColor: darkColors.purple, color: lightColors.cyan}}
  />
  <Link tooltip={"Ação 0"} icon="fas fa-plus" href="/baaah"/>
  <Button tooltip={"Ação 0"} tooltip="Inline container" rotate>Bah!</Button>
</Container>```

It does not affects previous features of the lib, already existing things still working the same